### PR TITLE
Fix hal include path and failing tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 CC = arm-none-eabi-gcc
 AR = arm-none-eabi-ar
 CFLAGS = -Wall -Wextra -O2 -std=c11 -mcpu=cortex-m4 -mthumb -mfloat-abi=hard -mfpu=fpv4-sp-d16
-INCLUDES = -Iinclude
+INCLUDES = -Iinclude -I.
 LDFLAGS = -lm
 
 # Directories

--- a/tests/automotive/test_key_fob_analyzer.c
+++ b/tests/automotive/test_key_fob_analyzer.c
@@ -101,10 +101,11 @@ void test_keyfob_capture_null_signal() {
 void test_keyfob_analyze_valid() {
     signal_data_t signal;
     keyfob_analysis_t result_data;
+    uint8_t mock_data[64] = {0};
 
     // Setup mock signal data
-    signal.data = NULL;
-    signal.length = 0;
+    signal.data = mock_data;
+    signal.length = sizeof(mock_data);
     signal.frequency = 315000000;
     signal.timestamp = 0;
 
@@ -142,9 +143,10 @@ void test_keyfob_analyze_null_result() {
 void test_keyfob_rolling_code_valid() {
     signal_data_t signal;
     rolling_code_info_t info;
+    uint8_t mock_data[64] = {0};
 
-    signal.data = NULL;
-    signal.length = 0;
+    signal.data = mock_data;
+    signal.length = sizeof(mock_data);
 
     bool result = keyfob_detect_rolling_code(&signal, &info);
 


### PR DESCRIPTION
Fixes compilation error when building `mdk_predator` and fixes failing tests in `test_key_fob_analyzer`.

Compilation error occurred because `src/mdk_predator.c` included `hal/hal.h`, which required the repository root to be in the include path. The `Makefile` was updated to include `-I.`.

Two tests were failing in `tests/automotive/test_key_fob_analyzer.c` because they passed a `NULL` buffer for `signal.data`, which incorrectly tested the happy path (where input validation is triggered and returns false). They were updated to provide an actual mock buffer, allowing the tests to pass. All tests now pass successfully.

---
*PR created automatically by Jules for task [18183861919133531625](https://jules.google.com/task/18183861919133531625) started by @limbo111111*